### PR TITLE
Wrong path for Capistrano recipes require

### DIFF
--- a/lib/dotenv/deployment/capistrano.rb
+++ b/lib/dotenv/deployment/capistrano.rb
@@ -3,7 +3,7 @@ require 'capistrano/version'
 if defined?(Capistrano::VERSION) && Capistrano::VERSION >= '3.0'
   raise 'Please read https://github.com/bkeepers/dotenv-deployment#capistrano to update your dotenv configuration for new Capistrano version'
 else
-  require 'dotenv/capistrano/recipes'
+  require 'dotenv/deployment/capistrano/recipes'
 
   Capistrano::Configuration.instance(:must_exist).load do
     before "deploy:finalize_update", "dotenv:symlink"


### PR DESCRIPTION
I was welcomed with error below while trying to deploy my app using Capistrano v2.x

```
in `require': cannot load such file -- dotenv/capistrano/recipes (LoadError)
```

So here's a quick fix.
