### PR TITLE
Passing empty filenames to load and overload

### DIFF
--- a/lib/dotenv/deployment.rb
+++ b/lib/dotenv/deployment.rb
@@ -3,10 +3,16 @@ require "dotenv/deployment/version"
 
 # Load defaults from .env or *.env in config
 Dotenv.load('.env')
-Dotenv.load(*Dir.glob("#{Rails.root}/config/**/*.env")) if defined?(Rails)
+if defined?(Rails)
+  filenames = Dir.glob("#{Rails.root}/config/**/*.env")
+  Dotenv.load(*filenames) if not filenames.empty?
+end
 
 # Override any existing variables if an environment-specific file exists
 if environment = ENV['RACK_ENV'] || (defined?(Rails) && Rails.env)
   Dotenv.overload(".env.#{environment}")
-  Dotenv.overload(*Dir.glob("#{Rails.root}/config/**/*.env.#{environment}")) if defined?(Rails)
+  if defined?(Rails)
+    filenames = Dir.glob("#{Rails.root}/config/**/*.env.#{environment}")
+    Dotenv.overload(*filenames) if not filenames.empty?
+  end
 end


### PR DESCRIPTION
Passing empty filenames to load and overload causes reload of .env which reverses previous loading.  For example, ".env.development" on (now) line 13 is elimintated by (now) line 16 if not protected this way.