### PR TITLE
Setting dotenv_role doesn't work

### DIFF
--- a/lib/dotenv/deployment/capistrano/recipes.rb
+++ b/lib/dotenv/deployment/capistrano/recipes.rb
@@ -1,7 +1,7 @@
 Capistrano::Configuration.instance(:must_exist).load do
   _cset(:dotenv_path){ "#{shared_path}/.env" }
 
-  symlink_args = (role = fetch(:dotenv_role, nil) ? {:roles => role} : {})
+  symlink_args = (role = fetch(:dotenv_role, nil)) ? {:roles => role} : {}
 
   namespace :dotenv do
     desc "Symlink shared .env to current release"


### PR DESCRIPTION
Turns out the parens are slightly off so that the role variable wasn't getting set.
