### PR TITLE
Fixes a load issue with specific .env files in Rails apps

### DIFF
--- a/lib/dotenv/deployment.rb
+++ b/lib/dotenv/deployment.rb
@@ -1,7 +1,7 @@
 require "dotenv"
 require "dotenv/deployment/version"
 
-rails_root = File.absolute_path("./")
+rails_root = Rails.root || Dir.pwd
 
 # Load defaults from .env or *.env in config
 Dotenv.load('.env')


### PR DESCRIPTION
Using `Rails.root` returns `nil` before the application boot. This commit solves the issue by determining the Rails root with `File.absolute_path`. Fixes #18 
