### PR TITLE
Fixes #13 .env overrides .env.#{environment}

### DIFF
--- a/lib/dotenv/deployment.rb
+++ b/lib/dotenv/deployment.rb
@@ -9,7 +9,7 @@ Dotenv.load(*Dir.glob("#{Rails.root}/config/**/*.env")) if defined?(Rails)
 if environment = ENV['RACK_ENV'] || (defined?(Rails) && Rails.env)
   Dotenv.overload(".env.#{environment}")
   if defined?(Rails)
-    config_env = Dir.glob("#{Rails.root}/config/**/.env.#{environment}")
+    config_env = Dir.glob("#{Rails.root}/config/**/{*.env.#{environment},.env.#{environment}}")
     Dotenv.overload(*config_env) if config_env.any?
   end
 end

--- a/lib/dotenv/deployment.rb
+++ b/lib/dotenv/deployment.rb
@@ -8,5 +8,8 @@ Dotenv.load(*Dir.glob("#{Rails.root}/config/**/*.env")) if defined?(Rails)
 # Override any existing variables if an environment-specific file exists
 if environment = ENV['RACK_ENV'] || (defined?(Rails) && Rails.env)
   Dotenv.overload(".env.#{environment}")
-  Dotenv.overload(*Dir.glob("#{Rails.root}/config/**/*.env.#{environment}")) if defined?(Rails)
+  if defined?(Rails)
+    config_env = Dir.glob("#{Rails.root}/config/**/.env.#{environment}")
+    Dotenv.overload(*config_env) if config_env.any?
+  end
 end


### PR DESCRIPTION
Fix #13 
Remove extra asterisk *.env => .env
Overload only if not empty