### PR TITLE
Update deployment.rb

### DIFF
--- a/lib/dotenv/deployment.rb
+++ b/lib/dotenv/deployment.rb
@@ -10,5 +10,5 @@ Dotenv.load(*Dir.glob("#{rails_root}/config/**/*.env")) if defined?(Rails)
 # Override any existing variables if an environment-specific file exists
 if environment = ENV['RACK_ENV'] || (defined?(Rails) && Rails.env)
   Dotenv.overload(".env.#{environment}")
-  Dotenv.overload(*Dir.glob("#{rails_root}/config/**/*.env.#{environment}")) if defined?(Rails)
+  Dotenv.overload(*Dir.glob("#{rails_root}/config/**/*.env.#{environment}", File::FNM_DOTMATCH)) if defined?(Rails)
 end


### PR DESCRIPTION
Add File::FNM_DOTMATCH as a second parameter to Dir.glob to force it to match dotfiles.
Previous pattern matched 'production.env.production', but didn't match '.env.production'.