### PR TITLE
This gem is deprecated

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0 - Mar 5, 2014
+
+* This gem is now deprecated.
+
 ## 0.2.0 - Oct 3, 2014
 
 * Declare dependency on dotenv ~>1.0

--- a/README.md
+++ b/README.md
@@ -1,56 +1,13 @@
 # dotenv-deployment
 
-[dotenv](https://github.com/bkeepers/dotenv) is designed to load configuration variables into `ENV` in *development*. It does not concern itself with production environments because there are typically better ways to manage configuration in those environments—such as `/etc/environment` managed by [Puppet](https://github.com/puppetlabs/puppet) or [Chef](https://github.com/opscode/chef), `heroku config`, etc.
+**This gem is deprecated and no longer maintained. Use `dotenv-rails`, or manually configure [dotenv](https://github.com/bkeepers/dotenv) to meet your own needs.**
 
-However, some find dotenv to be a convenient way to configure applications in staging and production environments. This gem makes it easier to do that by adding support for:
-
-* [multiple environments](#multiple-environments)
-* [Capistrano](#capistrano)
-
-## Installation
-
-Add this line to your application's Gemfile:
-
-    gem 'dotenv-deployment'
-
-And then execute:
-
-    $ bundle
-
-## Usage
-
-## Multiple Environments
-
-By default `.env` will be loaded when `dotenv/deployment` is required. It will not override existing environment variables.
-
-If you're using Rails or `ENV['RACK_ENV']` is set, an environment-specific file (like `.env.production`) will be loaded and override any existing variables. In a Rails project, `config/*.env` and `config/*.env.#{environment}` will also be loaded.
-
-## Capistrano
-
-### Capistrano 2
-
-Add the gem to your `config/deploy.rb` file:
+If the environment files for your Rails application are in `config`, add the following lines to `config/application.rb` to maintain the behavior that this gem provided.
 
 ```ruby
-require "dotenv/deployment/capistrano"
+# Load defaults from config/*.env in config
+Dotenv.load *Dir.glob(Rails.root.join("config/**/*.env"), File::FNM_DOTMATCH))
+
+# Override any existing variables if an environment-specific file exists
+Dotenv.overload *Dir.glob(Rails.root.join("config/**/*.env.#{Rails.env}"), File::FNM_DOTMATCH)
 ```
-
-**NOTE: If you are upgrading from previous versions of dotenv, you will need to change your require from "dotenv/capistrano" to "dotenv/deployment/capistrano".**
-
-It will symlink the `.env` located in `/path/to/shared` in the new release.
-
-### Capistrano 3
-
-This gem is not needed; Capistrano 3 has a baked-in mechanism for symlinking files. Just add `.env` to the list of linked files, for example:
-
-```ruby
-set :linked_files, %w{config/database.yml .env}
-```
-
-## Contributing
-
-1. Fork it ( http://github.com/bkeepers/dotenv-deployment/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request

--- a/lib/dotenv/deployment.rb
+++ b/lib/dotenv/deployment.rb
@@ -1,7 +1,7 @@
 require "dotenv"
 require "dotenv/deployment/version"
 
-rails_root = Rails.root || Dir.pwd
+rails_root = Rails.root || Dir.pwd if defined?(Rails)
 
 # Load defaults from .env or *.env in config
 Dotenv.load('.env')

--- a/lib/dotenv/deployment.rb
+++ b/lib/dotenv/deployment.rb
@@ -1,6 +1,8 @@
 require "dotenv"
 require "dotenv/deployment/version"
 
+warn "[DEPRECATION] the dotenv-deployment gem is deprecated. See https://github.com/bkeepers/dotenv-deployment#readme."
+
 rails_root = Rails.root || Dir.pwd if defined?(Rails)
 
 # Load defaults from .env or *.env in config

--- a/lib/dotenv/deployment/version.rb
+++ b/lib/dotenv/deployment/version.rb
@@ -1,5 +1,5 @@
 module Dotenv
   module Deployment
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
dotenv-rails 2.0 (https://github.com/bkeepers/dotenv/pull/160) will restore support for multiple environments and this gem will no longer be needed.